### PR TITLE
Add extended Unlearning lyrics

### DIFF
--- a/docs/unlearning-album.md
+++ b/docs/unlearning-album.md
@@ -1,0 +1,146 @@
+# Unlearning (Millennial Manifesto)
+
+A concept album exploring self-love, boundary setting, and unlearning toxic narratives. Each track channels the voice of a millennial in today's world—sarcastic, unapologetic, and quick to call out political hypocrisy.
+
+## Tracklist
+
+1. **Intro: Reboot**
+
+   - Spoken-word with sampled modem sounds.
+   - Sets the stage for letting go of old programs and rewriting personal code.
+   - **Lyrics**:
+
+     ```
+     Booting up the system, clearing out the crust,
+     Old myths crashing, leave them in the dust.
+     Welcome to the reboot, watch me redefine,
+     Fresh start loaded—this millennium is mine.
+     Crashing old illusions, restart to align,
+     Code from the ashes, new path by design.
+     System check complete, new software within,
+     Ready for the update, let the future begin.
+     ```
+
+2. **Self Love 101**
+
+   - Hook: "I’m my own idol, class is in session."
+   - Celebrates radical self-respect and educated Black culture.
+   - References generational wisdom from elders and how education empowers.
+   - **Lyrics**:
+
+     ```
+     Mirror on the wall says I’m everything I need,
+     Degrees on the shelf but my soul takes the lead.
+     No more second-guessing, self-love is the plan,
+     Learned from my people how to rise and take a stand.
+     Chapters unwritten, I'm penning them bold,
+     Textbooks outdated, I'm breaking the mold.
+     From ancestors' lessons to modern mind hacks,
+     Self-love revolution, we're taking it back.
+     ```
+
+3. **Boundary Lines**
+
+   - Upbeat tempo with sharp hi-hats.
+   - Talks about drawing lines in the sand against haters and energy vampires.
+   - "If your vibe’s off, I ghost like I’m software in dev mode."
+   - **Lyrics**:
+
+     ```
+     Firewall’s up—don’t cross that line,
+     Drain me once, you won’t get a second time.
+     My circle’s tight like code in review,
+     Respect the boundaries or I’ll debug you.
+     Cut the noise quick like a zero-day patch,
+     Guarding my energy, no strings to latch.
+     If you can't respect, you won't get near,
+     Code compiled strong, my intentions clear.
+     ```
+
+4. **Unlearn**
+
+   - Reflective track about dismantling outdated beliefs.
+   - Chorus: "Delete that folder, clear that cache."
+   - Encourages listeners to question toxic systems they were taught.
+   - **Lyrics**:
+
+     ```
+     Strip away the dogma like I’m wiping drives,
+     Reinstall my thinking—new script, new lives.
+     Question every lesson that was built on fear,
+     Unlearning old lies ’til the message comes clear.
+     Break the cycle, question every rule,
+     Erase old scripts they taught in school.
+     Rewire my purpose beyond the past,
+     Freedom in the process, unlearning fast.
+     ```
+
+5. **Political Theatre**
+
+   - Sarcastic commentary on leaders overstepping boundaries.
+   - Direct callouts of Trump and other bad role models.
+   - "Clowns in suits, but the joke’s on us if we stay silent."
+   - **Lyrics**:
+
+     ```
+     Watch the circus broadcast on repeat,
+     Promises and side shows piling on deceit.
+     I won’t play the extra in their tragic play,
+     Spotlight on the truth—we’re voting them away.
+     Mask off the lies hiding in plain sight,
+     Distraction tactics keep us up at night.
+     From tweets to scandals, the drama plays on,
+     We write the final act once the smoke is gone.
+     ```
+
+6. **No More Capes**
+
+   - Discusses dropping the hero complex and embracing community.
+   - "We’re the crew, not just sidekicks waiting for a savior."
+   - Celebrates collective power and mutual support.
+   - **Lyrics**:
+
+     ```
+     Put the cape down, grab a neighbor’s hand,
+     Super strength in numbers when we take a stand.
+     No lone savior riding in to save the day,
+     We build together—let the people lead the way.
+     Every neighbor hero in their own right,
+     Sharing our power in the daylight.
+     Side by side we craft a brand-new song,
+     Together unstoppable, proud and strong.
+     ```
+
+7. **Vampires at the Door**
+
+   - Darker beat with heavy bass.
+   - Lists the ways negativity can drain ambition.
+   - Ends with a chant: "Block, delete, protect my peace."
+   - **Lyrics**:
+
+     ```
+     Night creeps in with whispers of doubt,
+     Energy thieves tryna suck me out.
+     But I bar the gate, keep my focus keen,
+     Block, delete—my aura stays clean.
+     They feed on drama, but I fast from stress,
+     Cut off their supply—my peace is blessed.
+     Armor of clarity, they can't ignore,
+     Standing tall, they won't reach me anymore.
+     ```
+
+8. **Outro: Millennial Laughs**
+   - Returns to a comedic tone, mocking generational stereotypes.
+   - Ends on a high note with the line: "We survived dial‑up, we can survive this."
+   - **Lyrics**:
+
+     ```
+     Laughing at the labels they tried to assign,
+     Still here thriving, sipping on my wine.
+     From dial-up tones to the memes we create,
+     Millennial pride—it’s never too late.
+     Scroll through the chaos, still we push ahead,
+     Group chats blazing while the rumors spread.
+     We remix the culture with every new meme,
+     Fade out on laughter—millennial dream.
+     ```


### PR DESCRIPTION
## Summary
- expand each track in `docs/unlearning-album.md` with full lyrics

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck` *(fails: missing node types)*

------
https://chatgpt.com/codex/tasks/task_e_68561c6c6288832facfbaf48aacc2897