### PR TITLE
Add alt version of Unlearning album

### DIFF
--- a/docs/unlearning-album-v2.md
+++ b/docs/unlearning-album-v2.md
@@ -1,0 +1,173 @@
+# Unlearning (Millennial Manifesto) - Version 2
+
+A second take on the album, delivering sharper punchlines and weed-friendly humor. Each track
+explores self-love, boundaries, and political critique from a millennial perspective.
+
+## Tracklist
+
+1. **Intro: Reboot Again**
+
+   - Sampling startup chimes over a heavy beat.
+   - **Lyrics**:
+     ```
+     Power surge rising, spark up the night,
+     Another reboot, everything's in sight.
+     Old code failing, watch it collapse,
+     Fresh program running—no time to relapse.
+     Patch over heartache, let the smoke rise,
+     Laughter and vision alive in my eyes.
+     Keys clicking quick while we coast on this vibe,
+     Breaking the silence, reclaiming our tribe.
+     Firewall up, haters can't cling,
+     Debugging the drama with each bell ring.
+     System overloaded, free of the rust,
+     We boot once more—elevated and just.
+     Dreams compiled smooth, leaving the past,
+     Millennial uprising coded to last.
+     ```
+
+2. **Self Love 2.0**
+
+   - Mirror raps with confident affirmations.
+   - **Lyrics**:
+     ```
+     Wake up glowing, can't dim my flame,
+     Learned my worth, won't play the same.
+     Planting my peace like rows of green,
+     Wisdom in the smoke, mind freshly clean.
+     Skin like gold, shimmering loud,
+     Black brilliance walking tall and proud.
+     Every lesson earned through hustle and grind,
+     Boundless resilience shaping my mind.
+     Critics bounce off, they can't connect,
+     Self-celebration shows full effect.
+     Books on the shelf, but my soul writes more,
+     Learning to live beyond the score.
+     Breathing in hope with every breath,
+     Self love 2.0—built to the death.
+     ```
+
+3. **Firewall Boundaries**
+
+   - Fast tempo with pulsing bass.
+   - **Lyrics**:
+     ```
+     Swipe left on vampires draining my day,
+     Security protocols keep them at bay.
+     Energy locked tight, vibe pure and strong,
+     Test my limits—you're gone before long.
+     Ghost mode active when motives are shady,
+     I keep the team real, never acting lazy.
+     Quick with the cutoff, no second guess,
+     Boundaries coded to filter the stress.
+     One strike, you're out, no restart,
+     My peace protected, guarding my heart.
+     Weed rolled tight as I watch them disperse,
+     Firewall blazing, reversing the curse.
+     No leeches allowed in this digital zone,
+     Authentic connections or leave me alone.
+     ```
+
+4. **Unlearn Everything**
+
+   - Reflective vibe with heavy echo.
+   - **Lyrics**:
+     ```
+     Delete the dogma, empty the cache,
+     History's glitch we gladly smash.
+     Reprogram thoughts once filled with dread,
+     New algorithms humming in my head.
+     Question the past with each new release,
+     Old fears fade while confidence leaps.
+     Smoke trails lighten the weight I carried,
+     Unlearned restrictions once deeply buried.
+     Fresh framework built from community love,
+     Upgraded spirit fits hand in glove.
+     Shifting beliefs to a higher zone,
+     Boundless potential finally known.
+     Forward we code, unstoppable force,
+     Millennial minds steering the course.
+     ```
+
+5. **Political Clowns**
+
+   - Satirical track blasting bad leaders.
+   - **Lyrics**:
+     ```
+     Big top politics, same tired show,
+     Lies in a loop with nowhere to go.
+     Trump tweets flailing, clinging to power,
+     We laugh it off, watching towers sour.
+     Empty promises piled sky high,
+     We light one up, kiss them goodbye.
+     Stage props crumbling as truth takes hold,
+     People united, determined and bold.
+     Fact-check punches land every round,
+     Crowds chanting loud with a thunderous sound.
+     Smoke clearing now, illusions undone,
+     Our votes fired back—revolution begun.
+     Headlines shaking, spotlight on change,
+     Millennial voices rewriting the range.
+     ```
+
+6. **Drop the Hero Mask**
+
+   - Anthem for collective power.
+   - **Lyrics**:
+     ```
+     No more capes flying solo in the sky,
+     We'll rise together, watch egos die.
+     Neighborhood heroes stand side by side,
+     Community rhythm, unstoppable tide.
+     Fame can't buy the strength we share,
+     Power in numbers, always aware.
+     Sarcasm sharp, our laughter free,
+     Building a future with unity's key.
+     We trade in illusions for real connection,
+     Spreading the wealth of each intersection.
+     Pass the torch, let everyone shine,
+     Hands intertwined, purpose divine.
+     The era of saviors now out of view,
+     Collective potential—version two.
+     ```
+
+7. **Energy Vampires**
+
+   - Dark beat with triumphant chorus.
+   - **Lyrics**:
+     ```
+     Shadows lurking, hungry for spark,
+     I keep my aura lit in the dark.
+     Fakes fall back when my defenses ignite,
+     Block, delete—end of the night.
+     Drama detectors sound the alarm,
+     Peace mode engaged, safe from harm.
+     No more draining my mental bank,
+     I cut them off quick—give no thanks.
+     Rolling resilience, smoke in the air,
+     Psychic leeches step back if they dare.
+     Clear intentions guard my door,
+     Sanctified spirit ready for more.
+     Chanting aloud, my mantra thrives:
+     Protect my peace—where freedom survives.
+     ```
+
+8. **Outro: Laugh It Off**
+   - Playful finale mocking stereotypes.
+   - **Lyrics**:
+     ```
+     Scroll fatigue fades while we laugh on cue,
+     Survived the chaos, built something new.
+     Memes keep rolling, stress steps aside,
+     Jokers to the left, real ones to ride.
+     Dial-up roots but high-speed dreams,
+     Streaming our stories with digital beams.
+     Every joke sharper, our humor prime,
+     Millennial spirit ahead of its time.
+     Puff out the tension, let go the frown,
+     Closing the album, energy down.
+     Smiles contagious as we sign off tonight,
+     Passing the mic to keep futures bright.
+     Fade with a laugh, feel the weight shift,
+     Millennial manifesto—final lift.
+     ```

--- a/docs/unlearning-album.md
+++ b/docs/unlearning-album.md
@@ -1,0 +1,210 @@
+# Unlearning (Millennial Manifesto)
+
+A concept album exploring self-love, boundary setting, and unlearning toxic narratives. Each track channels the voice of a millennial in today's world—sarcastic, unapologetic, and quick to call out political hypocrisy.
+
+## Tracklist
+
+1. **Intro: Reboot**
+
+   - Spoken-word with sampled modem sounds.
+   - Sets the stage for letting go of old programs and rewriting personal code.
+   - **Lyrics**:
+
+     ```
+     Booting up the system, clearing out the crust,
+     Old myths crashing, leave them in the dust.
+     Welcome to the reboot, watch me redefine,
+     Fresh start loaded—this millennium is mine.
+     Hit the reset switch, pass around the green,
+     Code from the ashes, life in widescreen.
+     System check complete, new software within,
+     Ready for the update, let the future begin.
+     Bugs in the code? I debug my past,
+     Hard reset heartache, I’m free at last.
+     Patch every memory with a brighter tone,
+     Sync with my vision, rewriting my own.
+     Data transferring from doubt to trust,
+     Haters on mute while my dreams combust.
+     Boot sequence done, stepping out to win,
+     Log off the old world, new era set in.
+     ```
+
+2. **Self Love 101**
+
+   - Hook: "I’m my own idol, class is in session."
+   - Celebrates radical self-respect and educated Black culture.
+   - References generational wisdom from elders and how education empowers.
+   - **Lyrics**:
+
+     ```
+     Mirror on the wall says I’m all that I need,
+     Degrees on the shelf but my soul takes the lead.
+     No more guessing games, self-love is the plan,
+     Learned from my people how to rise and take a stand.
+     Chapters unwritten, I’m scripting them bold,
+     Textbooks outdated, I'm breaking the mold.
+     Ancestors whisper with modern mind hacks,
+     Self-love uprising—yeah, we're taking it back.
+     Grateful for the skin that glows in its tone,
+     Affirm every morning in a confident tone.
+     Culture in my veins guides each decision,
+     Roll up some wisdom to sharpen my vision.
+     Critiques bounce off this bulletproof pride,
+     Stretch marks and scars—I've nothing to hide.
+     No apologies for the love that I keep,
+     In this millennial glow, my roots run deep.
+     ```
+
+3. **Boundary Lines**
+
+   - Upbeat tempo with sharp hi-hats.
+   - Talks about drawing lines in the sand against haters and energy vampires.
+   - "If your vibe’s off, I ghost like I’m software in dev mode."
+   - **Lyrics**:
+
+     ```
+     Firewall’s up—don’t cross that line,
+     Drain me once, you won’t get a second time.
+     My circle’s tight like code in review,
+     Respect the boundaries or I’ll debug you.
+     Cut the noise quick like a zero-day patch,
+     Guarding my energy, no strings to latch.
+     Bring good vibes or you won’t get near,
+     Silence the static with a firm shutdown,
+     Permissions revoked if you bring me down.
+     Updates roll out when I shift my route,
+     Boundary protocol leaves no doubt.
+     You test my limits, system locks you out,
+     Friends in my network all know what I'm about.
+     Roll one and chill or lose access,
+     Firewall blazing—nothing less.
+     Code compiled strong, intentions clear.
+     ```
+
+4. **Unlearn**
+
+   - Reflective track about dismantling outdated beliefs.
+   - Chorus: "Delete that folder, clear that cache."
+   - Encourages listeners to question toxic systems they were taught.
+   - **Lyrics**:
+
+     ```
+     Strip away the dogma like I’m wiping drives,
+     Reinstall my thinking—new script, new lives.
+     Question every lesson born out of fear,
+     Unlearning old lies till the truth is clear.
+     Break the cycle, question every rule,
+     Delete the old scripts they taught in school.
+     Rewire my purpose beyond the past,
+     Wisdom uploaded so the freedom lasts.
+     Breaking the chains that tightened control,
+     New algorithms liberate my soul.
+     Erase the myths we used to find,
+     Puff on reflection, expand my mind.
+     Install empathy, upgrade my stance,
+     Open-source spirit gives growth a chance.
+     Backup my values, no glitch inside,
+     Unlearning complete—system fortified.
+     ```
+
+5. **Political Theatre**
+
+   - Sarcastic commentary on leaders overstepping boundaries.
+   - Direct callouts of Trump and other bad role models.
+   - "Clowns in suits, but the joke’s on us if we stay silent."
+   - **Lyrics**:
+
+     ```
+     Watch the circus stream on endless repeat,
+     Promises and sideshows heavy with deceit.
+     I won’t be the extra in their tragic play,
+     Spotlight the truth—we’re voting them away.
+     Mask off the lies hiding in plain sight,
+     Their late-night tweets keep me up at night.
+     Puffing resilience while the drama drags on,
+     Poll numbers fall like their last excuse,
+     Fact checks loaded—I cut their abuse.
+     Echo chambers crumble when we speak direct,
+     Power to the people, now watch us connect.
+     Empty podiums echo with our demands,
+     Lighting one up, we build change with our hands.
+     Voter rolls rising, system reboot,
+     March to the beat of real truths in pursuit,
+     We write the final act once the smoke is gone.
+     ```
+
+6. **No More Capes**
+
+   - Discusses dropping the hero complex and embracing community.
+   - "We’re the crew, not just sidekicks waiting for a savior."
+   - Celebrates collective power and mutual support.
+   - **Lyrics**:
+
+     ```
+     Put the cape down, grab a neighbor’s hand,
+     Super strength in numbers when we take a stand.
+     No lone savior riding in to save the day,
+     We build together—let the people lead the way.
+     Every neighbor hero in their own right,
+     Sharing power freely in the daylight.
+     Side by side, we craft a brand-new song,
+     Community power always keeps us strong.
+     We trade capes for unity, walking with pride,
+     Champions rising from every side.
+     Under one banner the mission completes,
+     Giving and taking in balanced exchange.
+     No pedestal heroes, just teamwork arranged.
+     Spark up some hope as we forge ahead,
+     Collective resilience—the capes stay shed.
+     Together unstoppable, proud and well-fed.
+     ```
+
+7. **Vampires at the Door**
+
+   - Darker beat with heavy bass.
+   - Lists the ways negativity can drain ambition.
+   - Ends with a chant: "Block, delete, protect my peace."
+   - **Lyrics**:
+
+     ```
+     Night creeps in with whispers of doubt,
+     Energy thieves tryna suck me out.
+     I bar the gate, keep my focus keen,
+     Block, delete—my aura stays clean.
+     They feed on drama, I pass on that mess,
+     Cut off their supply—my peace is blessed.
+     Armor of clarity, they can't ignore,
+     Hollow words vanish when I shut the door.
+     Draining connections get cut at the core,
+     Nightlife illusions can't steal my drive.
+     Conscious in my steps, I keep hope alive.
+     Roll up a minute and breathe in the code,
+     Negative signals fail to upload.
+     Ritual of strength, release and repeat,
+     Chant "protect my peace"—the cycle's complete.
+     Standing tall, they won't reach me anymore.
+     ```
+
+8. **Outro: Millennial Laughs**
+   - Returns to a comedic tone, mocking generational stereotypes.
+   - Ends on a high note with the line: "We survived dial‑up, we can survive this."
+   - **Lyrics**:
+
+     ```
+     Laughing at the labels they tried to assign,
+     Still here thriving, sipping on my wine.
+     From dial-up tones to the memes we create,
+     Millennial pride—it’s never too late.
+     Scroll through the chaos, still we push ahead,
+     Group chats blazing while the rumors spread.
+     We remix the culture with every new meme,
+     Eye rolls ready when the critics scream.
+     Jokes sharper than a midday roast,
+     Streaming our stories with the loudest boast.
+     Every setback's fuel—watch the glow begin,
+     Puff out the stress, breathe the good vibes in.
+     From brunch debates to late-night threads,
+     We’re rewriting futures while the timeline spreads.
+     Friends across time zones share the same theme,
+     Fade out on laughter—millennial dream.
+     ```


### PR DESCRIPTION
## Summary
- add `docs/unlearning-album-v2.md` with an alternate set of millennial manifesto lyrics

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run typecheck` *(fails: missing node types)*

------
https://chatgpt.com/codex/tasks/task_e_68561c6c6288832facfbaf48aacc2897